### PR TITLE
Update patches for RHEL 8

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,6 @@
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>rmw_fastrtps_cpp</depend>
   <depend>std_msgs</depend>
 
   <test_depend>ament_cmake_pytest</test_depend>

--- a/rpm/template.spec.em
+++ b/rpm/template.spec.em
@@ -1,3 +1,8 @@
+@{
+# FastRTPS is not available for RHEL 8 - ignore any deps related to it
+Depends = [d for d in Depends if 'fastrtps' not in d]
+BuildDepends = [d for d in BuildDepends if 'fastrtps' not in d]
+}@
 %bcond_without tests
 %bcond_without weak_deps
 


### PR DESCRIPTION
This change should be **fast-forward** merged after review.

Note that the dependency is soft, and the package can successfully build without it: https://github.com/ros2/demos/blob/ed0299dc808f94b3c995dd4530680560e07226ff/demo_nodes_cpp_native/CMakeLists.txt#L19